### PR TITLE
Fix margins in chat view

### DIFF
--- a/app/src/main/res/layout/message_received.xml
+++ b/app/src/main/res/layout/message_received.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<LinearLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:layout_margin="8dp">
+        android:orientation="vertical">
     <TextView
             android:id="@+id/message"
             android:background="@drawable/received_message_bubble"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            android:gravity="start"
+            android:layout_gravity="start"
             android:padding="8dp"
+            android:gravity="start"
             android:textColor="@android:color/white"/>
-</android.support.constraint.ConstraintLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/message_sent.xml
+++ b/app/src/main/res/layout/message_sent.xml
@@ -10,8 +10,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
-            android:layout_margin="8dp"
-            android:gravity="end"
             android:padding="8dp"
+            android:gravity="end"
             android:textColor="@android:color/white"/>
 </LinearLayout>


### PR DESCRIPTION
The margins were awful and uneven because I left a android.support.constraint.ConstraintLayout in when it should've been a LinearLayout.