### PR TITLE
Speed up Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ before_cache:
 
 cache:
   directories:
-    - $HOME/.gradle/cache
-    - $HOME/libs
-    - $HOME/jnilibs
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.android/build-cache/
 
 script:
   - yes | sdkmanager "platforms;android-28"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ cache:
 script:
   - yes | sdkmanager "platforms;android-28"
   - ./download-deps.sh
-  - ./gradlew assemble
+  - ./gradlew --parallel testDebug


### PR DESCRIPTION
Improve our cache paths, run gradle in parallel, and only do a debug build.
This more than halves our build time.