### PR TITLE
Disable warning about app not being indexed by Google

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,7 @@ android {
     }
     lintOptions {
         disable 'InvalidPackage' // TODO(robinlinden): Delete/update invalid packages
+        disable 'GoogleAppIndexingWarning'
     }
 }
 


### PR DESCRIPTION
Not sure we even can fix this warning in a nicer way, but we should look into it eventually.