### PR TITLE
Disable send button until recipient is online

### DIFF
--- a/app/src/main/java/ltd/evilcorp/atox/activity/ChatActivity.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/activity/ChatActivity.kt
@@ -4,26 +4,43 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
+import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.activity_chat.*
-import ltd.evilcorp.atox.*
+import ltd.evilcorp.atox.App
+import ltd.evilcorp.atox.R
+import ltd.evilcorp.atox.repository.ContactRepository
 import ltd.evilcorp.atox.tox.ToxThread
 import ltd.evilcorp.atox.ui.MessagesAdapter
+import ltd.evilcorp.atox.vo.ConnectionStatus
 import ltd.evilcorp.atox.vo.MessageModel
 import ltd.evilcorp.atox.vo.Sender
+import javax.inject.Inject
 
 class ChatActivity : AppCompatActivity() {
     private val messagesModel = ArrayList<MessageModel>()
 
+    @Inject
+    lateinit var contactRepository: ContactRepository
+
+    private var contactOnline = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
+        AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_chat)
 
         val adapter = MessagesAdapter(this, messagesModel)
         messages.adapter = adapter
 
-        send.setOnClickListener {
-            val friendNumber: Int = intent.getIntExtra("friendNumber", 0)
+        val friendNumber: Int = intent.getIntExtra("friendNumber", 0)
+        val contact = contactRepository.getContact(friendNumber)
+        contact.observe(this, Observer {
+            contactOnline = it.connectionStatus != ConnectionStatus.NONE
+            updateSendButton()
+        })
 
+        send.setOnClickListener {
             with(App.toxThread.handler) {
                 sendMessage(obtainMessage(ToxThread.msgSendMsg, friendNumber, 0, outgoingMessage.text.toString()))
             }
@@ -43,10 +60,16 @@ class ChatActivity : AppCompatActivity() {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
-                send.isEnabled = s!!.toString().isNotEmpty()
+                updateSendButton()
             }
         })
 
+        updateSendButton()
+
         toolbar.title = intent.getStringExtra("username")
+    }
+
+    private fun updateSendButton() {
+        send.isEnabled = outgoingMessage.text.isNotEmpty() && contactOnline
     }
 }

--- a/app/src/main/java/ltd/evilcorp/atox/db/ContactDatabase.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/db/ContactDatabase.kt
@@ -2,9 +2,34 @@ package ltd.evilcorp.atox.db
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverter
+import androidx.room.TypeConverters
+import ltd.evilcorp.atox.vo.ConnectionStatus
 import ltd.evilcorp.atox.vo.Contact
+import ltd.evilcorp.atox.vo.UserStatus
+
+private class Converters {
+    companion object {
+        @TypeConverter
+        @JvmStatic
+        fun toStatus(status: Int): UserStatus = UserStatus.values()[status]
+
+        @TypeConverter
+        @JvmStatic
+        fun fromStatus(status: UserStatus): Int = status.ordinal
+
+        @TypeConverter
+        @JvmStatic
+        fun toConnection(connection: Int): ConnectionStatus = ConnectionStatus.values()[connection]
+
+        @TypeConverter
+        @JvmStatic
+        fun fromConnection(connection: ConnectionStatus): Int = connection.ordinal
+    }
+}
 
 @Database(entities = [Contact::class], version = 1, exportSchema = false)
+@TypeConverters(Converters::class)
 abstract class ContactDatabase : RoomDatabase() {
     abstract fun contactDao(): ContactDao
 }

--- a/app/src/main/java/ltd/evilcorp/atox/di/ActivityModule.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/di/ActivityModule.kt
@@ -2,6 +2,7 @@ package ltd.evilcorp.atox.di
 
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
+import ltd.evilcorp.atox.activity.ChatActivity
 import ltd.evilcorp.atox.activity.ContactListActivity
 import ltd.evilcorp.atox.activity.ProfileActivity
 
@@ -13,4 +14,7 @@ abstract class ActivityModule {
 
     @ContributesAndroidInjector
     abstract fun contactListInjector(): ContactListActivity
+
+    @ContributesAndroidInjector
+    abstract fun chatInjector(): ChatActivity
 }

--- a/app/src/main/java/ltd/evilcorp/atox/di/ContactModule.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/di/ContactModule.kt
@@ -2,6 +2,8 @@ package ltd.evilcorp.atox.di
 
 import android.app.Application
 import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
 import dagger.Module
 import dagger.Provides
 import ltd.evilcorp.atox.db.ContactDao
@@ -15,6 +17,7 @@ class ContactModule {
     fun provideDatabase(application: Application): ContactDatabase {
         return Room.databaseBuilder(application, ContactDatabase::class.java, "contact_db")
             .allowMainThreadQueries()
+            .fallbackToDestructiveMigration() // TODO(robinlinden): Delete this.
             .build()
     }
 

--- a/app/src/main/java/ltd/evilcorp/atox/vo/Contact.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/vo/Contact.kt
@@ -2,7 +2,6 @@ package ltd.evilcorp.atox.vo
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
-import androidx.room.Ignore
 import androidx.room.PrimaryKey
 
 // This is a 1:1 mapping of the ToxConnection enum in tox4j and needs to stay that way.
@@ -19,6 +18,7 @@ enum class UserStatus {
     BUSY,
 }
 
+// TODO(robinlinden): The transient data either needs to be fixed on save or load or it needs to live in a separate in-memory database.
 @Entity(tableName = "contacts")
 data class Contact(
     @PrimaryKey
@@ -31,15 +31,14 @@ data class Contact(
     @ColumnInfo(name = "status_message")
     var statusMessage: String = "...",
     @ColumnInfo(name = "last_message")
-    var lastMessage: String = "Never"
-) {
-    @Ignore
-    var status: UserStatus = UserStatus.NONE
-    @Ignore
-    var connectionStatus: ConnectionStatus = ConnectionStatus.NONE
-    @Ignore
+    var lastMessage: String = "Never",
+    @ColumnInfo(name = "status")
+    var status: UserStatus = UserStatus.NONE,
+    @ColumnInfo(name = "connection_status")
+    var connectionStatus: ConnectionStatus = ConnectionStatus.NONE,
+    @ColumnInfo(name = "typing")
     var typing: Boolean = false
-
+) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -49,10 +48,10 @@ data class Contact(
         if (!publicKey.contentEquals(other.publicKey)) return false
         if (friendNumber != other.friendNumber) return false
         if (name != other.name) return false
-        if (status != other.status) return false
         if (statusMessage != other.statusMessage) return false
-        if (connectionStatus != other.connectionStatus) return false
         if (lastMessage != other.lastMessage) return false
+        if (status != other.status) return false
+        if (connectionStatus != other.connectionStatus) return false
         if (typing != other.typing) return false
 
         return true
@@ -62,10 +61,10 @@ data class Contact(
         var result = publicKey.contentHashCode()
         result = 31 * result + friendNumber
         result = 31 * result + name.hashCode()
-        result = 31 * result + status.hashCode()
         result = 31 * result + statusMessage.hashCode()
-        result = 31 * result + connectionStatus.hashCode()
         result = 31 * result + lastMessage.hashCode()
+        result = 31 * result + status.hashCode()
+        result = 31 * result + connectionStatus.hashCode()
         result = 31 * result + typing.hashCode()
         return result
     }


### PR DESCRIPTION
We should set up faux offline message sending, but this is quicker and easier and fixes that tox4j explodes if you send a message to someone who isn't there.

I stuck the transient data back in the database as otherwise we don't get callbacks on it.