### PR TITLE
Fix maxLineHeight warning in contact list view

### DIFF
--- a/app/src/main/res/layout/contact_list_view_item.xml
+++ b/app/src/main/res/layout/contact_list_view_item.xml
@@ -28,6 +28,6 @@
             android:id="@+id/publicKey"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:maxLines="1"
+            android:singleLine="true"
             android:ellipsize="end"/>
 </LinearLayout>


### PR DESCRIPTION
This fixes the `W/StaticLayout: maxLineHeight should not be -1.  maxLines:1 lineCount:1` spam in the contact list.