### PR TITLE
Add dummy data to ui components

### DIFF
--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -30,7 +30,8 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/toolbar"
-            app:layout_constraintBottom_toTopOf="@+id/outgoingMessage"/>
+            app:layout_constraintBottom_toTopOf="@+id/outgoingMessage"
+            tools:listitem="@layout/message_received"/>
     <EditText
             android:id="@+id/outgoingMessage"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_contact_list.xml
+++ b/app/src/main/res/layout/activity_contact_list.xml
@@ -32,7 +32,8 @@
             <ListView
                     android:id="@+id/contactList"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"/>
+                    android:layout_height="match_parent"
+                    tools:listitem="@layout/contact_list_view_item"/>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/app/src/main/res/layout/contact_list_view_item.xml
+++ b/app/src/main/res/layout/contact_list_view_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical"
@@ -16,18 +17,21 @@
                 android:layout_height="wrap_content"
                 android:gravity="start"
                 android:layout_weight=".7"
-                android:textStyle="bold"/>
+                android:textStyle="bold"
+                tools:text="name goes here"/>
         <TextView
                 android:id="@+id/lastMessage"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="end"
-                android:layout_weight=".3"/>
+                android:layout_weight=".3"
+                tools:text="28 May 2019 11:49 "/>
     </LinearLayout>
     <TextView
             android:id="@+id/publicKey"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:singleLine="true"
-            android:ellipsize="end"/>
+            android:ellipsize="end"
+            tools:text="PUBLIC KEY GOES HERE AND GOES ON AND ON AND ON AND ON"/>
 </LinearLayout>

--- a/app/src/main/res/layout/message_received.xml
+++ b/app/src/main/res/layout/message_received.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
@@ -12,5 +13,6 @@
             android:layout_gravity="start"
             android:padding="8dp"
             android:gravity="start"
-            android:textColor="@android:color/white"/>
+            android:textColor="@android:color/white"
+            tools:text="Message I received"/>
 </LinearLayout>

--- a/app/src/main/res/layout/message_sent.xml
+++ b/app/src/main/res/layout/message_sent.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
@@ -12,5 +13,6 @@
             android:layout_gravity="end"
             android:padding="8dp"
             android:gravity="end"
-            android:textColor="@android:color/white"/>
+            android:textColor="@android:color/white"
+            tools:text="Message I sent"/>
 </LinearLayout>


### PR DESCRIPTION
The tools namespace is only used inside the IDE and populates ui components to make changing the layouts less of a chore. Before this, most of the ui stuff isn't even visible in the ui preview things in Android Studio.