### PR TITLE
Reset transient contact data on startup and fix loading friend number from Tox

### DIFF
--- a/app/src/main/java/ltd/evilcorp/atox/db/ContactDao.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/db/ContactDao.kt
@@ -1,16 +1,16 @@
 package ltd.evilcorp.atox.db
 
 import androidx.lifecycle.LiveData
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room.*
 import ltd.evilcorp.atox.vo.Contact
 
 @Dao
 interface ContactDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun save(contact: Contact)
+
+    @Update
+    fun update(contact: Contact)
 
     @Query("SELECT COUNT(*) FROM contacts WHERE public_key = :publicKey")
     fun exists(publicKey: ByteArray): Boolean

--- a/app/src/main/java/ltd/evilcorp/atox/repository/ContactRepository.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/repository/ContactRepository.kt
@@ -18,6 +18,10 @@ class ContactRepository @Inject constructor(
         contactDao.save(contact)
     }
 
+    fun updateContact(contact: Contact) {
+        contactDao.update(contact)
+    }
+
     fun getContact(publicKey: ByteArray): LiveData<Contact> {
         return contactDao.load(publicKey)
     }

--- a/app/src/main/java/ltd/evilcorp/atox/tox/ToxThread.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/tox/ToxThread.kt
@@ -9,6 +9,7 @@ import im.tox.tox4j.core.options.SaveDataOptions
 import im.tox.tox4j.core.options.ToxOptions
 import ltd.evilcorp.atox.repository.ContactRepository
 import ltd.evilcorp.atox.repository.MessageRepository
+import ltd.evilcorp.atox.vo.ConnectionStatus
 import ltd.evilcorp.atox.vo.Contact
 import javax.inject.Inject
 
@@ -129,6 +130,8 @@ class ToxThread(
                         override fun onChanged(contact: Contact?) {
                             Log.e("tox", "contact loaded: $friendNumber")
                             contact!!.friendNumber = friendNumber
+                            contact.connectionStatus = ConnectionStatus.NONE
+                            contact.typing = false
                             this@with.removeObserver(this)
                             contactRepository.updateContact(contact)
                         }

--- a/app/src/main/java/ltd/evilcorp/atox/tox/ToxThread.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/tox/ToxThread.kt
@@ -130,6 +130,7 @@ class ToxThread(
                             Log.e("tox", "contact loaded: $friendNumber")
                             contact!!.friendNumber = friendNumber
                             this@with.removeObserver(this)
+                            contactRepository.updateContact(contact)
                         }
                     }
                     this.observeForever(observer)

--- a/app/src/main/java/ltd/evilcorp/atox/vo/Contact.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/vo/Contact.kt
@@ -17,7 +17,6 @@ enum class UserStatus {
     BUSY,
 }
 
-// TODO(robinlinden): The transient data either needs to be fixed on save or load or it needs to live in a separate in-memory database.
 @Entity(tableName = "contacts")
 data class Contact(
     @PrimaryKey


### PR DESCRIPTION
At first I was only going to reset the transient data, but turns out that our friend number loading never worked.