### PR TITLE
 Hook up messaging

### DIFF
--- a/app/src/main/java/ltd/evilcorp/atox/activity/ChatActivity.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/activity/ChatActivity.kt
@@ -5,12 +5,16 @@ import androidx.appcompat.app.AppCompatActivity
 import dagger.android.AndroidInjection
 import ltd.evilcorp.atox.R
 import ltd.evilcorp.atox.repository.ContactRepository
+import ltd.evilcorp.atox.repository.MessageRepository
 import ltd.evilcorp.atox.ui.ChatFragment
 import javax.inject.Inject
 
 class ChatActivity : AppCompatActivity() {
     @Inject
     lateinit var contactRepository: ContactRepository
+
+    @Inject
+    lateinit var messageRepository: MessageRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
@@ -21,7 +25,11 @@ class ChatActivity : AppCompatActivity() {
             supportFragmentManager.beginTransaction()
                 .replace(
                     R.id.container,
-                    ChatFragment.newInstance(intent.getIntExtra("friendNumber", -1), contactRepository)
+                    ChatFragment.newInstance(
+                        intent.getByteArrayExtra("publicKey"),
+                        contactRepository,
+                        messageRepository
+                    )
                 )
                 .commitNow()
         }

--- a/app/src/main/java/ltd/evilcorp/atox/activity/ContactListActivity.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/activity/ContactListActivity.kt
@@ -98,17 +98,7 @@ class ContactListActivity : AppCompatActivity(), NavigationView.OnNavigationItem
 
     fun openChat(view: View) {
         val intent = Intent(this, ChatActivity::class.java)
-
-        //TODO(endoffile78) figure out a better way to get the friend number
-        var friendNumber = 0
-        contacts.forEach {
-            if (it.name == view.name.text) {
-                friendNumber = it.friendNumber
-                return@forEach
-            }
-        }
-
-        intent.putExtra("friendNumber", friendNumber)
+        intent.putExtra("publicKey", view.publicKey.text.toString().hexToByteArray())
         startActivity(intent)
     }
 }

--- a/app/src/main/java/ltd/evilcorp/atox/db/Converters.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/db/Converters.kt
@@ -1,0 +1,34 @@
+package ltd.evilcorp.atox.db
+
+import androidx.room.TypeConverter
+import ltd.evilcorp.atox.vo.ConnectionStatus
+import ltd.evilcorp.atox.vo.Sender
+import ltd.evilcorp.atox.vo.UserStatus
+
+internal class Converters {
+    companion object {
+        @TypeConverter
+        @JvmStatic
+        fun toStatus(status: Int): UserStatus = UserStatus.values()[status]
+
+        @TypeConverter
+        @JvmStatic
+        fun fromStatus(status: UserStatus): Int = status.ordinal
+
+        @TypeConverter
+        @JvmStatic
+        fun toConnection(connection: Int): ConnectionStatus = ConnectionStatus.values()[connection]
+
+        @TypeConverter
+        @JvmStatic
+        fun fromConnection(connection: ConnectionStatus): Int = connection.ordinal
+
+        @TypeConverter
+        @JvmStatic
+        fun toSender(sender: Int): Sender = Sender.values()[sender]
+
+        @TypeConverter
+        @JvmStatic
+        fun fromSender(sender: Sender): Int = sender.ordinal
+    }
+}

--- a/app/src/main/java/ltd/evilcorp/atox/db/Database.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/db/Database.kt
@@ -30,6 +30,6 @@ private class Converters {
 
 @Database(entities = [Contact::class], version = 1, exportSchema = false)
 @TypeConverters(Converters::class)
-abstract class ContactDatabase : RoomDatabase() {
+abstract class Database : RoomDatabase() {
     abstract fun contactDao(): ContactDao
 }

--- a/app/src/main/java/ltd/evilcorp/atox/db/Database.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/db/Database.kt
@@ -2,34 +2,13 @@ package ltd.evilcorp.atox.db
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import androidx.room.TypeConverter
 import androidx.room.TypeConverters
-import ltd.evilcorp.atox.vo.ConnectionStatus
 import ltd.evilcorp.atox.vo.Contact
-import ltd.evilcorp.atox.vo.UserStatus
+import ltd.evilcorp.atox.vo.Message
 
-private class Converters {
-    companion object {
-        @TypeConverter
-        @JvmStatic
-        fun toStatus(status: Int): UserStatus = UserStatus.values()[status]
-
-        @TypeConverter
-        @JvmStatic
-        fun fromStatus(status: UserStatus): Int = status.ordinal
-
-        @TypeConverter
-        @JvmStatic
-        fun toConnection(connection: Int): ConnectionStatus = ConnectionStatus.values()[connection]
-
-        @TypeConverter
-        @JvmStatic
-        fun fromConnection(connection: ConnectionStatus): Int = connection.ordinal
-    }
-}
-
-@Database(entities = [Contact::class], version = 1, exportSchema = false)
+@Database(entities = [Contact::class, Message::class], version = 2, exportSchema = false)
 @TypeConverters(Converters::class)
 abstract class Database : RoomDatabase() {
     abstract fun contactDao(): ContactDao
+    abstract fun messageDao(): MessageDao
 }

--- a/app/src/main/java/ltd/evilcorp/atox/db/MessageDao.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/db/MessageDao.kt
@@ -1,0 +1,17 @@
+package ltd.evilcorp.atox.db
+
+import androidx.lifecycle.LiveData
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import ltd.evilcorp.atox.vo.Message
+
+@Dao
+interface MessageDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun save(message: Message)
+
+    @Query("SELECT * FROM messages where conversation == :conversation")
+    fun load(conversation: ByteArray): LiveData<List<Message>>
+}

--- a/app/src/main/java/ltd/evilcorp/atox/di/AppComponent.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/di/AppComponent.kt
@@ -7,5 +7,5 @@ import ltd.evilcorp.atox.App
 import javax.inject.Singleton
 
 @Singleton
-@Component(modules = [AndroidInjectionModule::class, ApplicationModule::class, ActivityModule::class, ContactModule::class])
+@Component(modules = [AndroidInjectionModule::class, ApplicationModule::class, ActivityModule::class, DatabaseModule::class])
 interface AppComponent : AndroidInjector<App>

--- a/app/src/main/java/ltd/evilcorp/atox/di/DatabaseModule.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/di/DatabaseModule.kt
@@ -6,6 +6,7 @@ import dagger.Module
 import dagger.Provides
 import ltd.evilcorp.atox.db.ContactDao
 import ltd.evilcorp.atox.db.Database
+import ltd.evilcorp.atox.db.MessageDao
 import javax.inject.Singleton
 
 @Module
@@ -21,7 +22,13 @@ class DatabaseModule {
 
     @Singleton
     @Provides
-    fun provideDao(db: Database): ContactDao {
+    fun provideContactDao(db: Database): ContactDao {
         return db.contactDao()
+    }
+
+    @Singleton
+    @Provides
+    fun provideMessageDao(db: Database): MessageDao {
+        return db.messageDao()
     }
 }

--- a/app/src/main/java/ltd/evilcorp/atox/di/DatabaseModule.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/di/DatabaseModule.kt
@@ -2,20 +2,18 @@ package ltd.evilcorp.atox.di
 
 import android.app.Application
 import androidx.room.Room
-import androidx.room.RoomDatabase
-import androidx.sqlite.db.SupportSQLiteDatabase
 import dagger.Module
 import dagger.Provides
 import ltd.evilcorp.atox.db.ContactDao
-import ltd.evilcorp.atox.db.ContactDatabase
+import ltd.evilcorp.atox.db.Database
 import javax.inject.Singleton
 
 @Module
-class ContactModule {
+class DatabaseModule {
     @Singleton
     @Provides
-    fun provideDatabase(application: Application): ContactDatabase {
-        return Room.databaseBuilder(application, ContactDatabase::class.java, "contact_db")
+    fun provideDatabase(application: Application): Database {
+        return Room.databaseBuilder(application, Database::class.java, "contact_db")
             .allowMainThreadQueries()
             .fallbackToDestructiveMigration() // TODO(robinlinden): Delete this.
             .build()
@@ -23,7 +21,7 @@ class ContactModule {
 
     @Singleton
     @Provides
-    fun provideDao(db: ContactDatabase): ContactDao {
+    fun provideDao(db: Database): ContactDao {
         return db.contactDao()
     }
 }

--- a/app/src/main/java/ltd/evilcorp/atox/repository/MessageRepository.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/repository/MessageRepository.kt
@@ -1,0 +1,20 @@
+package ltd.evilcorp.atox.repository
+
+import androidx.lifecycle.LiveData
+import ltd.evilcorp.atox.db.MessageDao
+import ltd.evilcorp.atox.vo.Message
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MessageRepository @Inject constructor(
+    private val messageDao: MessageDao
+) {
+    fun add(message: Message) {
+        messageDao.save(message)
+    }
+
+    fun get(conversation: ByteArray): LiveData<List<Message>> {
+        return messageDao.load(conversation)
+    }
+}

--- a/app/src/main/java/ltd/evilcorp/atox/tox/Tox.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/tox/Tox.kt
@@ -5,11 +5,12 @@ import im.tox.tox4j.core.enums.ToxMessageType
 import im.tox.tox4j.core.options.ToxOptions
 import im.tox.tox4j.impl.jni.ToxCoreImpl
 import ltd.evilcorp.atox.repository.ContactRepository
+import ltd.evilcorp.atox.repository.MessageRepository
 import java.io.File
 
-class Tox(options: ToxOptions, contactRepository: ContactRepository) {
+class Tox(options: ToxOptions, contactRepository: ContactRepository, messageRepository: MessageRepository) {
     private val tox: ToxCoreImpl = ToxCoreImpl(options)
-    private val eventListener = ToxEventListener(contactRepository)
+    private val eventListener = ToxEventListener(contactRepository, messageRepository)
 
     fun bootstrap(address: String, port: Int, publicKey: ByteArray) {
         tox.bootstrap(address, port, publicKey)

--- a/app/src/main/java/ltd/evilcorp/atox/tox/ToxEventListener.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/tox/ToxEventListener.kt
@@ -7,12 +7,16 @@ import im.tox.tox4j.core.enums.ToxFileControl
 import im.tox.tox4j.core.enums.ToxMessageType
 import im.tox.tox4j.core.enums.ToxUserStatus
 import ltd.evilcorp.atox.repository.ContactRepository
+import ltd.evilcorp.atox.repository.MessageRepository
 import ltd.evilcorp.atox.vo.Contact
+import ltd.evilcorp.atox.vo.Message
+import ltd.evilcorp.atox.vo.Sender
 import java.text.DateFormat
 import java.util.*
 
 class ToxEventListener(
-    private val contactRepository: ContactRepository
+    private val contactRepository: ContactRepository,
+    private val messageRepository: MessageRepository
 ) : ToxCoreEventListener<Int> {
     private var contacts: List<Contact> = ArrayList()
 
@@ -79,6 +83,8 @@ class ToxEventListener(
         with(contactByFriendNumber(friendNumber)) {
             lastMessage = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(Date())
             contactRepository.addContact(this)
+
+            messageRepository.add(Message(this.publicKey, String(message), Sender.Received))
         }
 
         return Log.e("ToxCore", "friendMessage")

--- a/app/src/main/java/ltd/evilcorp/atox/tox/ToxThread.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/tox/ToxThread.kt
@@ -8,19 +8,24 @@ import im.tox.tox4j.core.options.ProxyOptions
 import im.tox.tox4j.core.options.SaveDataOptions
 import im.tox.tox4j.core.options.ToxOptions
 import ltd.evilcorp.atox.repository.ContactRepository
+import ltd.evilcorp.atox.repository.MessageRepository
 import ltd.evilcorp.atox.vo.Contact
 import javax.inject.Inject
 
-class ToxThreadFactory @Inject constructor(private val contactRepository: ContactRepository) {
+class ToxThreadFactory @Inject constructor(
+    private val contactRepository: ContactRepository,
+    private val messageRepository: MessageRepository
+) {
     fun create(saveDestination: String, saveOption: SaveDataOptions): ToxThread {
-        return ToxThread(saveDestination, saveOption, contactRepository)
+        return ToxThread(saveDestination, saveOption, contactRepository, messageRepository)
     }
 }
 
 class ToxThread(
     saveDestination: String,
     saveOption: SaveDataOptions,
-    contactRepository: ContactRepository
+    contactRepository: ContactRepository,
+    messageRepository: MessageRepository
 ) : HandlerThread("Tox") {
     companion object {
         // Tox
@@ -61,7 +66,8 @@ class ToxThread(
             saveOption,
             true
         ),
-        contactRepository
+        contactRepository,
+        messageRepository
     )
 
     val handler: Handler by lazy {

--- a/app/src/main/java/ltd/evilcorp/atox/ui/ChatFragment.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/ui/ChatFragment.kt
@@ -15,7 +15,7 @@ import ltd.evilcorp.atox.R
 import ltd.evilcorp.atox.repository.ContactRepository
 import ltd.evilcorp.atox.tox.ToxThread
 import ltd.evilcorp.atox.vo.ConnectionStatus
-import ltd.evilcorp.atox.vo.MessageModel
+import ltd.evilcorp.atox.vo.Message
 import ltd.evilcorp.atox.vo.Sender
 
 class ChatFragment(val friendNumber: Int, val contactRepository: ContactRepository) : Fragment() {
@@ -57,7 +57,7 @@ class ChatFragment(val friendNumber: Int, val contactRepository: ContactReposito
                 )
             }
 
-            viewModel.messages.add(MessageModel(layout.outgoingMessage.text.toString(), Sender.Sent))
+            viewModel.messages.add(Message(layout.outgoingMessage.text.toString(), Sender.Sent))
             adapter.notifyDataSetChanged()
             layout.outgoingMessage.text.clear()
         }

--- a/app/src/main/java/ltd/evilcorp/atox/ui/ChatViewModel.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/ui/ChatViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import ltd.evilcorp.atox.repository.ContactRepository
 import ltd.evilcorp.atox.vo.Contact
-import ltd.evilcorp.atox.vo.MessageModel
+import ltd.evilcorp.atox.vo.Message
 
 class ChatViewModel(friendNumber: Int, contactRepository: ContactRepository) : ViewModel() {
     val contact: LiveData<Contact> = contactRepository.getContact(friendNumber)
-    val messages = ArrayList<MessageModel>()
+    val messages = ArrayList<Message>()
 }

--- a/app/src/main/java/ltd/evilcorp/atox/ui/ChatViewModel.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/ui/ChatViewModel.kt
@@ -3,10 +3,15 @@ package ltd.evilcorp.atox.ui
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import ltd.evilcorp.atox.repository.ContactRepository
+import ltd.evilcorp.atox.repository.MessageRepository
 import ltd.evilcorp.atox.vo.Contact
 import ltd.evilcorp.atox.vo.Message
 
-class ChatViewModel(friendNumber: Int, contactRepository: ContactRepository) : ViewModel() {
-    val contact: LiveData<Contact> = contactRepository.getContact(friendNumber)
-    val messages = ArrayList<Message>()
+class ChatViewModel(
+    publicKey: ByteArray,
+    contactRepository: ContactRepository,
+    messageRepository: MessageRepository
+) : ViewModel() {
+    val contact: LiveData<Contact> = contactRepository.getContact(publicKey)
+    val messages: LiveData<List<Message>> = messageRepository.get(publicKey)
 }

--- a/app/src/main/java/ltd/evilcorp/atox/ui/MessageAdapter.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/ui/MessageAdapter.kt
@@ -16,7 +16,9 @@ private fun inflateView(type: Sender, inflater: LayoutInflater): View =
         true
     )
 
-class MessagesAdapter(private val inflater: LayoutInflater, private val messages: MutableList<Message>) : BaseAdapter() {
+class MessagesAdapter(private val inflater: LayoutInflater) : BaseAdapter() {
+    var messages: List<Message> = ArrayList()
+
     override fun getCount(): Int = messages.size
     override fun getItem(position: Int): Any = messages[position]
     override fun getItemId(position: Int): Long = position.toLong()

--- a/app/src/main/java/ltd/evilcorp/atox/ui/MessageAdapter.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/ui/MessageAdapter.kt
@@ -6,7 +6,7 @@ import android.view.ViewGroup
 import android.widget.BaseAdapter
 import android.widget.TextView
 import ltd.evilcorp.atox.R
-import ltd.evilcorp.atox.vo.MessageModel
+import ltd.evilcorp.atox.vo.Message
 import ltd.evilcorp.atox.vo.Sender
 
 private fun inflateView(type: Sender, inflater: LayoutInflater): View =
@@ -16,7 +16,7 @@ private fun inflateView(type: Sender, inflater: LayoutInflater): View =
         true
     )
 
-class MessagesAdapter(private val inflater: LayoutInflater, private val messages: MutableList<MessageModel>) : BaseAdapter() {
+class MessagesAdapter(private val inflater: LayoutInflater, private val messages: MutableList<Message>) : BaseAdapter() {
     override fun getCount(): Int = messages.size
     override fun getItem(position: Int): Any = messages[position]
     override fun getItemId(position: Int): Long = position.toLong()

--- a/app/src/main/java/ltd/evilcorp/atox/vo/Message.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/vo/Message.kt
@@ -5,4 +5,4 @@ enum class Sender {
     Received,
 }
 
-class MessageModel(val message: String, val sender: Sender)
+class Message(val message: String, val sender: Sender)

--- a/app/src/main/java/ltd/evilcorp/atox/vo/Message.kt
+++ b/app/src/main/java/ltd/evilcorp/atox/vo/Message.kt
@@ -1,8 +1,45 @@
 package ltd.evilcorp.atox.vo
 
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
 enum class Sender {
     Sent,
     Received,
 }
 
-class Message(val message: String, val sender: Sender)
+@Entity(tableName = "messages")
+data class Message(
+    @ColumnInfo(name = "conversation")
+    val publicKey: ByteArray,
+
+    @ColumnInfo(name = "message")
+    val message: String,
+
+    @ColumnInfo(name = "sender")
+    val sender: Sender
+) {
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "id")
+    var id: Long = 0
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Message
+
+        if (!publicKey.contentEquals(other.publicKey)) return false
+        if (message != other.message) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = publicKey.contentHashCode()
+        result = 31 * result + message.hashCode()
+        result = 31 * result + id.hashCode()
+        return result
+    }
+}


### PR DESCRIPTION
A notable change is that we only really use the friend number in the tox module now.

The way the messages database is currently set up is that the public key of the friend you're speaking with acts as the conversation identifier. (Meaning that we save the pubkey of our contact in every message entry.) We should set up proper IDs in the databases, but that would be a larger change and this works for now.

![messaging](https://user-images.githubusercontent.com/8304462/58750704-0c6de400-8496-11e9-9403-df0863e6c4a9.png)

Based on #80 